### PR TITLE
Pin actions to hashes using pinact [workflow-enforcer]

### DIFF
--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -1,0 +1,6 @@
+version: 3
+
+# TODO: Remove ignore once we have a global token to check private github actions.
+ignore_actions:
+  - name: MercuryTechnologies/mercury-github-actions/pinact-check
+    ref: "aa5ebb17717cc3279eb4f9f8f7386d746246037f"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -10,12 +10,12 @@ jobs:
     if: false # always skip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Run a one-line script
         run: echo Hello, world
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Run a one-line script
         run: echo Hello, world

--- a/.github/workflows/pinact-check.yml
+++ b/.github/workflows/pinact-check.yml
@@ -1,0 +1,15 @@
+name: Check that actions are pinned to hashes
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-pinact:
+    name: Run pinact check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: MercuryTechnologies/mercury-github-actions/pinact-check@aa5ebb17717cc3279eb4f9f8f7386d746246037f # v0.0.26


### PR DESCRIPTION
This PR pins action references to commit hashes to mitigate supply chain attacks where a bad actor will push a new tag or override an existing tag, leading to us running malicious code immediately without explicitly updating.

Documentation on how to use pinact can be found in the internal developers site.
